### PR TITLE
Initial cuda12.3 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+# This uses the cuda compiler v12.3, built in a private channel, to bootstrap.
+# This file should be removed the second time this package is built.
+channels:
+  - lc030263

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# To bootstrap. Should be removed when these entries go into the aggregate cbc.yaml.
+cuda_compiler_version:         # [linux and x86_64]
+  - 12.3                       # [linux and x86_64]
+cuda_compiler:                 # [linux and x86_64]
+  - cuda-nvcc                  # [linux and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 # To bootstrap. Should be removed when these entries go into the aggregate cbc.yaml.
-cuda_compiler_version:         # [linux and x86_64]
-  - 12.3                       # [linux and x86_64]
-cuda_compiler:                 # [linux and x86_64]
-  - cuda-nvcc                  # [linux and x86_64]
+cuda_compiler_version:
+  - 12.3
+cuda_compiler:
+  - cuda-nvcc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [osx]
+  skip: true  # [osx or (linux and s390x)]
   skip: true  # [cuda_compiler_version != "11.8"]
   ignore_run_exports_from:
     - {{ compiler("c") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ source:
 build:
   number: 0
   skip: true  # [osx or (linux and s390x)]
-  skip: true  # [cuda_compiler_version != "11.8"]
   ignore_run_exports_from:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4606](https://anaconda.atlassian.net/browse/PKG-4606) 
- [Upstream repository](https://github.com/conda-forge/cccl-feedstock)

### Explanation of changes:

For CUDA 12.4 build, following [conda-forge's pattern](https://github.com/conda-forge/staged-recipes/issues/21382) which was developed in conjunction with Nvidia. I don't see a need to stage these then release them all at once. They won't cause a problem released one at a time.
- Please check the main branch too, this has just been forked
- Replacement for [cuda-cccl-impl](https://github.com/AnacondaRecipes/cuda-cccl-impl-feedstock), cuda-cccl now consumes this package instead of that.


[PKG-4606]: https://anaconda.atlassian.net/browse/PKG-4606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ