### PR TITLE
cccl v3.1.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_stdlib_version:  # [linux]
+   - "2.28"        # [linux]
+
+# CCCL is a header-only library, we need to specify the CUDA compiler version for tests only
+cuda_compiler_version:
+  - 13.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cccl" %}
-{% set version = "3.0.1" %}
+{% set version = "3.1.4" %}
 
 # CUDA C++ Core Libraries (CCCL) includes thrust, cub, and libcudacxx. These are header-only libraries.
 # The cccl package ships CCCL headers in the environment's include directory for use in downstream recipes that require CCCL. It follows CCCL upstream versioning. Use this package to say, "I want a specific version of CCCL headers when building my package (which may be newer than the versions shipped in the latest CUDA Toolkit)."
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://github.com/NVIDIA/cccl/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8dbb11d6b1b16c84ed8511cf5e816d797598f627dbe8960a3aab0c9214aa308b
+  sha256: fe679225875b856dc31fbf63f26b8b447a02dae415c41d3815815f52aadf45a7
 
 build:
   number: 0


### PR DESCRIPTION
cccl 3.1.4

**Destination channel:** defaults

### Links

- [PKG-12000](https://anaconda.atlassian.net/browse/PKG-12000) 
- [Upstream repository](https://github.com/NVIDIA/cccl)
- [Upstream changelog/diff](https://github.com/NVIDIA/cccl/releases/tag/v3.1.4)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/libcurand-feedstock/pull/5

### Explanation of changes:

- CUDA 13.1 requires CCCL 3.1.4


[PKG-12000]: https://anaconda.atlassian.net/browse/PKG-12000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ